### PR TITLE
DRAFT: Demonstrating Grpc failure on Linux

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,28 @@
             "args": [
                 "${workspaceFolder}/out/cmake/Debug/source/Mlos.UnitTest/Mlos.UnitTest"
             ],
+            "env": {
+                "MLOS_SETTINGS_REGISTRY_PATH": "${workspaceFolder}/out/dotnet/source/Mlos.UnitTest/Mlos.UnitTest.SettingsRegistry/objd/AnyCPU"
+            },
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
+        {
+            "name": ".NET Core Launch (console) - Mlos.Agent.Server - SmartCache",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "", //"build",
+            "program": "${workspaceFolder}/out/dotnet/source/Mlos.Agent.Server/objd/AnyCPU/Mlos.Agent.Server.dll",
+            "args": [
+                "--executable",
+                "${workspaceFolder}/out/cmake/Debug/source/Examples/SmartCache/SmartCache",
+                "--optimizer-uri",
+                "http://localhost:50051"
+            ],
+            "env": {
+                "MLOS_SETTINGS_REGISTRY_PATH": "${workspaceFolder}/out/dotnet/source/Examples/SmartCache/SmartCache.SettingsRegistry/objd/AnyCPU"
+            },
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "internalConsole"

--- a/source/Mlos.Agent.GrpcClient/Mlos.Agent.GrpcClient.csproj
+++ b/source/Mlos.Agent.GrpcClient/Mlos.Agent.GrpcClient.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)..\..\build\Mlos.Common.props" />
   <PropertyGroup>
@@ -14,7 +14,9 @@
   </PropertyGroup>
   <Import Project="$(BaseDir)\build\Mlos.NetCore.props" />
   <Import Project="$(BaseDir)\build\Mlos.NetCore.Grpc.props" />
+  <!--
   <Import Project="$(BaseDir)\build\Mlos.NetCore.SingleFile.props" />
+  -->
   <ItemGroup>
     <Protobuf Include="..\Mlos.Agent.Proto\greet.proto" GrpcServices="Client" Link="ProtoBuffers\greet.proto" OutputDir="$(GrpcOutputDir)"/>
   </ItemGroup>

--- a/source/Mlos.Agent.Server/Mlos.Agent.Server.csproj
+++ b/source/Mlos.Agent.Server/Mlos.Agent.Server.csproj
@@ -11,14 +11,21 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <Import Project="$(BaseDir)\build\Mlos.NetCore.props" />
+  <!--
   <Import Project="$(BaseDir)\build\Mlos.NetCore.SingleFile.props" />
+  -->
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" GeneratePathProperty="true" />
     <BinplaceFile Include="$(PkgCommandLineParser)/lib/netstandard2.0/CommandLine.dll" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(SourceDir)\Mlos.Agent\Mlos.Agent.csproj" />
+    <!--
     <ProjectReference Include="$(SourceDir)\Mlos.Agent.GrpcServer\Mlos.Agent.GrpcServer.csproj" />
+    -->
     <ProjectReference Include="$(SourceDir)\Mlos.Streaming\Mlos.Streaming.csproj" />
     <ProjectReference Include="$(SourceDir)\Mlos.Model.Services.Client\Mlos.Model.Services.Client.csproj" />
     <ProjectReference Include="$(SourceDir)\Mlos.Model.Services\Mlos.Model.Services.csproj" />

--- a/source/Mlos.Agent.Server/MlosAgentServer.cs
+++ b/source/Mlos.Agent.Server/MlosAgentServer.cs
@@ -234,7 +234,7 @@ namespace Mlos.Agent.Server
                 }
             }
 
-            // Print any exceptions if occured.
+            // Print any exceptions if occurred.
             //
             if (mlosAgentTask.Exception != null)
             {

--- a/source/Mlos.Agent.Server/MlosAgentServer.cs
+++ b/source/Mlos.Agent.Server/MlosAgentServer.cs
@@ -104,10 +104,6 @@ namespace Mlos.Agent.Server
             {
                 Console.WriteLine("Connecting to the Mlos.Optimizer");
 
-                // This switch must be set before creating the GrpcChannel/HttpClient.
-                //
-                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-
                 // This populates a variable for the various settings registry
                 // callback handlers to use (by means of their individual
                 // AssemblyInitializers) to know how they can connect with the

--- a/source/Mlos.Agent.Server/MlosAgentServer.cs
+++ b/source/Mlos.Agent.Server/MlosAgentServer.cs
@@ -69,6 +69,7 @@ namespace Mlos.Agent.Server
             //
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2Support", true);
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+            ////AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
 
             string executableFilePath = null;
             Uri optimizerAddressUri = null;


### PR DESCRIPTION
Repro steps:

Expects Ubuntu 20.04.

There are some setup commands in the `Dockerfile` that can be used in a pinch if there are missing libraries or dependencies (e.g. for Python 3.7, pip dependencies, clang, etc.)

0. Get this branch:

```sh
git remote add github-bpkroth https://github.com/bpkroth/MLOS
git fetch --all
git checkout github-bpkroth/grpc-linux-fixups
```

1.
```sh
# In terminal 1, start the optimizer (leave it running):
python3.7 source/Mlos.Python/mlos/start_optimizer_microservice.py launch --port 50051
```

2. 
```sh
# In terminal 2
# - build the target
# (note this will fetch dotnet to tools/ if it hasn't already been done)
make CONFIGURATION=Debug -C source/Mlos.Agent.Server
# - run it, pointing it at the optimizer, but skip the executable
# (the Mlos.Agent.Server has hacked up in this branch for a minimal reproduction)
./tools/bin/dotnet out/dotnet/source/Mlos.Agent.Server/objd/AnyCPU/Mlos.Agent.Server.dll --optimizer-uri=http://localhost:50051
```

Output:
```txt
Mlos.Agent.Server
Connecting to the Mlos.Optimizer
Creating OptimizerProxy in Mlos.Agent.Server
switch_name System.Net.Http.SocketsHttpHandler.Http2Support was set: True
switch_name System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport was set: True
Unhandled exception. Grpc.Core.RpcException: Status(StatusCode=Internal, Detail="Bad gRPC response. Response protocol downgraded to HTTP/1.1.")
...
```