### PR TITLE
TESTING: Remove quotes from a docker label

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -591,7 +591,7 @@ jobs:
         # Add some labels for publishing.
         labels: |
           org.opencontainers.image.title=mlos-build-ubuntu-${{ matrix.UbuntuVersion }}
-          org.opencontainers.image.description="MLOS build environment for Ubuntu ${{ matrix.UbuntuVersion }}"
+          org.opencontainers.image.description=MLOS build environment for Ubuntu ${{ matrix.UbuntuVersion }}
           org.opencontainers.image.url=https://github.com/${{ github.repository }}
           org.opencontainers.image.source=https://github.com/${{ github.repository }}
           org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}


### PR DESCRIPTION
Should fix this error that recently showed up in our docker/build-push-action step:

"Error: Invalid Opening Quote: a quote is found inside a field at line 2"